### PR TITLE
Feature/support multiple remote registry on v.2.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . $DISTRIBUTION_DIR
 RUN CGO_ENABLED=0 make PREFIX=/go clean binaries && file ./bin/registry | grep "statically linked"
 
 FROM alpine
-COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
+COPY cmd/registry/config-multi-cache.yml /etc/docker/registry/config.yml
 COPY --from=build /go/src/github.com/docker/distribution/bin/registry /bin/registry
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000

--- a/cmd/registry/config-multi-cache.yml
+++ b/cmd/registry/config-multi-cache.yml
@@ -1,0 +1,20 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+proxy:
+  on: true
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -623,6 +623,15 @@ type Middleware struct {
 	Options Parameters `yaml:"options"`
 }
 
+type RemoteRegistry struct {
+	// URL is the remote registry url
+	URL string `yaml:"url"`
+	// Username for the registry
+	Username string `yaml:"username"`
+	// Password for the registry
+	Password string `yaml:"password"`
+}
+
 // Proxy configures the registry as a pull through cache
 type Proxy struct {
 	// RemoteURL is the URL of the remote registry
@@ -633,6 +642,12 @@ type Proxy struct {
 
 	// Password of the hub user
 	Password string `yaml:"password"`
+
+	// RemoteRegistries for supporting multiple remote registry url
+	RemoteRegistries []RemoteRegistry `yaml:"remoteregistries"`
+
+	// On is used to force turn on proxy, whenever there are RemoteRegistries / RemoteURL or not
+	On bool `yaml:"on"`
 }
 
 // Parse parses an input configuration yaml document into a Configuration struct

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -323,16 +323,14 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 	}
 
 	// configure as a pull through cache
-	if config.Proxy.On && config.Proxy.RemoteURL != "" {
+	if config.Proxy.RemoteURL != "" {
 		app.registry, err = proxy.NewRegistryPullThroughCache(ctx, app.registry, app.driver, config.Proxy)
 		if err != nil {
 			panic(err.Error())
 		}
 		app.isCache = true
 		dcontext.GetLogger(app).Info("Registry configured as a proxy cache to ", config.Proxy.RemoteURL)
-	}
-
-	if config.Proxy.On {
+	} else if config.Proxy.On {
 		// if config proxy on is true, and len(config.Proxy.RemoteRegistries) == 0, will return a
 		// very simple cache registry, with empty challengeManager, with empty scheduler(clean scheduler)
 		if len(config.Proxy.RemoteRegistries) == 0 {

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	cryptorand "crypto/rand"
+	"errors"
 	"expvar"
 	"fmt"
 	"math/rand"
@@ -24,7 +25,7 @@ import (
 	"github.com/docker/distribution/notifications"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/docker/distribution/registry/api/v2"
+	v2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/auth"
 	registrymiddleware "github.com/docker/distribution/registry/middleware/registry"
 	repositorymiddleware "github.com/docker/distribution/registry/middleware/repository"
@@ -96,7 +97,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		Config:  config,
 		Context: ctx,
 		router:  v2.RouterWithPrefix(config.HTTP.Prefix),
-		isCache: config.Proxy.RemoteURL != "",
+		isCache: (config.Proxy.RemoteURL != "" || len(config.Proxy.RemoteRegistries) != 0) && config.Proxy.On,
 	}
 
 	// Register the handler dispatchers.
@@ -316,8 +317,13 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		dcontext.GetLogger(app).Debugf("configured %q access controller", authType)
 	}
 
+	if config.Proxy.RemoteURL != "" && len(config.Proxy.RemoteRegistries) != 0 {
+		err = errors.New("config remote url and remote registries both is not allowed")
+		panic(err)
+	}
+
 	// configure as a pull through cache
-	if config.Proxy.RemoteURL != "" {
+	if config.Proxy.On && config.Proxy.RemoteURL != "" {
 		app.registry, err = proxy.NewRegistryPullThroughCache(ctx, app.registry, app.driver, config.Proxy)
 		if err != nil {
 			panic(err.Error())
@@ -325,6 +331,30 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		app.isCache = true
 		dcontext.GetLogger(app).Info("Registry configured as a proxy cache to ", config.Proxy.RemoteURL)
 	}
+
+	if config.Proxy.On {
+		// if config proxy on is true, and len(config.Proxy.RemoteRegistries) == 0, will return a
+		// very simple cache registry, with empty challengeManager, with empty scheduler(clean scheduler)
+		if len(config.Proxy.RemoteRegistries) == 0 {
+			app.registry, err = proxy.NewRegistryPullThroughWithNothing(ctx, app.registry, app.driver)
+			if err != nil {
+				panic(err.Error())
+			}
+			dcontext.GetLogger(app).Info("Registry configured as a registry with nothing pre-configs")
+		} else {
+			app.registry, err = proxy.NewRegistryPullThroughCacheOnRemoteRegistries(ctx, app.registry, app.driver, config.Proxy.RemoteRegistries)
+			if err != nil {
+				panic(err.Error())
+			}
+			var regs []string
+			for _, reg := range config.Proxy.RemoteRegistries {
+				regs = append(regs, reg.URL)
+			}
+			dcontext.GetLogger(app).Info("Registry configured as a proxy cache to ", regs)
+		}
+		app.isCache = true
+	}
+
 	var ok bool
 	app.repoRemover, ok = app.registry.(distribution.RepositoryRemover)
 	if !ok {
@@ -668,7 +698,6 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 
 		// Add username to request logging
 		context.Context = dcontext.WithLogger(context.Context, dcontext.GetLogger(context.Context, auth.UserNameKey))
-
 		// sync up context on the request.
 		r = r.WithContext(context)
 

--- a/registry/proxy/authconfig.go
+++ b/registry/proxy/authconfig.go
@@ -1,0 +1,22 @@
+package proxy
+
+// AuthConfig contains authorization information for connecting to a Registry
+type AuthConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+
+	// Email is an optional value associated with the username.
+	// This field is deprecated and will be removed in a later
+	// version of docker.
+	Email string `json:"email,omitempty"`
+
+	ServerAddress string `json:"serveraddress,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken string `json:"registrytoken,omitempty"`
+}

--- a/registry/proxy/emptyservice.go
+++ b/registry/proxy/emptyservice.go
@@ -1,0 +1,101 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/distribution/registry/client/auth/challenge"
+
+	"github.com/docker/distribution"
+	"github.com/opencontainers/go-digest"
+)
+
+type emptyBlobService struct {
+}
+
+func (*emptyBlobService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	return distribution.Descriptor{}, fmt.Errorf("sealer: empty blob stat, err: %s", distribution.ErrUnsupported)
+}
+
+func (*emptyBlobService) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	return []byte{}, fmt.Errorf("sealer: empty blob get, err: %s", distribution.ErrUnsupported)
+}
+
+func (*emptyBlobService) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	return nil, fmt.Errorf("sealer: empty blob open, err: %s", distribution.ErrUnsupported)
+}
+
+func (*emptyBlobService) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	return distribution.Descriptor{}, fmt.Errorf("sealer: empty blob put, err: %s", distribution.ErrUnsupported)
+}
+
+func (*emptyBlobService) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	return nil, fmt.Errorf("sealer: empty blob create, err: %s", distribution.ErrUnsupported)
+}
+
+func (*emptyBlobService) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	return nil, fmt.Errorf("sealer: empty blob resume, err: %s", distribution.ErrUnsupported)
+}
+
+type emptyManifestService struct {
+}
+
+func (*emptyManifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	return false, fmt.Errorf("sealer empty manifest exists, err: %s", distribution.ErrUnsupported)
+}
+
+func (*emptyManifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	return nil, fmt.Errorf("sealer empty manifest get, err: %s", distribution.ErrUnsupported)
+}
+
+func (*emptyManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	return "", fmt.Errorf("sealer empty manifest put, err: %s", distribution.ErrUnsupported)
+}
+
+func (*emptyManifestService) Delete(ctx context.Context, dgst digest.Digest) error {
+	return fmt.Errorf("sealer empty manifest delete, err: %s", distribution.ErrUnsupported)
+}
+
+type emptyChallenger struct {
+}
+
+func (*emptyChallenger) tryEstablishChallenges(context.Context) error {
+	return fmt.Errorf("sealer tryEstablishChallenges, err: %s", distribution.ErrUnsupported)
+}
+
+func (*emptyChallenger) credentialStore() auth.CredentialStore {
+	return nil
+}
+
+func (*emptyChallenger) challengeManager() challenge.Manager {
+	return nil
+}
+
+type emptyTagService struct {
+}
+
+func (*emptyTagService) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
+	return distribution.Descriptor{}, fmt.Errorf("sealer empty tag get, err: %s", distribution.ErrUnsupported)
+}
+
+// Tag associates the tag with the provided descriptor, updating the
+// current association, if needed.
+func (*emptyTagService) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
+	return fmt.Errorf("sealer empty tag tag, err: %s", distribution.ErrUnsupported)
+}
+
+// Untag removes the given tag association
+func (*emptyTagService) Untag(ctx context.Context, tag string) error {
+	return fmt.Errorf("sealer empty tag untag, err: %s", distribution.ErrUnsupported)
+}
+
+// All returns the set of tags managed by this tag service
+func (*emptyTagService) All(ctx context.Context) ([]string, error) {
+	return nil, fmt.Errorf("sealer empty tag all, err: %s", distribution.ErrUnsupported)
+}
+
+// Lookup returns the set of tags referencing the given digest.
+func (*emptyTagService) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+	return nil, fmt.Errorf("sealer empty tag lookup, err: %s", distribution.ErrUnsupported)
+}

--- a/registry/proxy/proxyauth.go
+++ b/registry/proxy/proxyauth.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/client/auth"
@@ -11,6 +12,8 @@ import (
 )
 
 const challengeHeader = "Docker-Distribution-Api-Version"
+
+var defaultHttpClient = &http.Client{Timeout: time.Second * 5}
 
 type userpass struct {
 	username string
@@ -57,7 +60,8 @@ func configureAuth(username, password, remoteURL string) (auth.CredentialStore, 
 func getAuthURLs(remoteURL string) ([]string, error) {
 	authURLs := []string{}
 
-	resp, err := http.Get(remoteURL + "/v2/")
+	//resp, err := http.Get(remoteURL + "/v2/")
+	resp, err := defaultHttpClient.Get(remoteURL + "/v2/")
 	if err != nil {
 		return nil, err
 	}

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -2,10 +2,16 @@ package proxy
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/configuration"
@@ -20,12 +26,21 @@ import (
 	"github.com/docker/distribution/registry/storage/driver"
 )
 
+var (
+	DefaultV2Registry = &url.URL{
+		Scheme: "https",
+		Host:   "registry-1.docker.io",
+	}
+)
+
 // proxyingRegistry fetches content from a remote registry and caches it locally
 type proxyingRegistry struct {
-	embedded       distribution.Namespace // provides local registry functionality
-	scheduler      *scheduler.TTLExpirationScheduler
-	remoteURL      url.URL
-	authChallenger authChallenger
+	embedded           distribution.Namespace // provides local registry functionality
+	scheduler          *scheduler.TTLExpirationScheduler
+	remoteURL          url.URL
+	authChallenger     authChallenger
+	authChallengers    map[string]authChallenger
+	authChallengersMux sync.RWMutex
 }
 
 // NewRegistryPullThroughCache creates a registry acting as a pull through cache
@@ -110,6 +125,115 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	}, nil
 }
 
+func NewRegistryPullThroughCacheOnRemoteRegistries(ctx context.Context, registry distribution.Namespace, driver driver.StorageDriver, remoteRegistries []configuration.RemoteRegistry) (distribution.Namespace, error) {
+	type remote struct {
+		url                      *url.URL
+		rawUrl, username, passwd string
+	}
+	var remotes []remote
+	for _, remoteRegistry := range remoteRegistries {
+		remoteURL, err := url.Parse(remoteRegistry.URL)
+		if err != nil {
+			return nil, err
+		}
+		// TODO maybe retrieve username/password from ~/.docker/config.json
+		remotes = append(remotes, remote{
+			url:      remoteURL,
+			rawUrl:   remoteRegistry.URL,
+			username: remoteRegistry.Username,
+			passwd:   remoteRegistry.Password,
+		})
+	}
+
+	v := storage.NewVacuum(ctx, driver)
+	s := scheduler.New(ctx, driver, "/scheduler-state.json")
+	s.OnBlobExpire(func(ref reference.Reference) error {
+		var r reference.Canonical
+		var ok bool
+		if r, ok = ref.(reference.Canonical); !ok {
+			return fmt.Errorf("unexpected reference type : %T", ref)
+		}
+
+		repo, err := registry.Repository(ctx, r)
+		if err != nil {
+			return err
+		}
+
+		blobs := repo.Blobs(ctx)
+
+		// Clear the repository reference and descriptor caches
+		err = blobs.Delete(ctx, r.Digest())
+		if err != nil {
+			return err
+		}
+
+		err = v.RemoveBlob(r.Digest().String())
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	s.OnManifestExpire(func(ref reference.Reference) error {
+		var r reference.Canonical
+		var ok bool
+		if r, ok = ref.(reference.Canonical); !ok {
+			return fmt.Errorf("unexpected reference type : %T", ref)
+		}
+
+		repo, err := registry.Repository(ctx, r)
+		if err != nil {
+			return err
+		}
+
+		manifests, err := repo.Manifests(ctx)
+		if err != nil {
+			return err
+		}
+		err = manifests.Delete(ctx, r.Digest())
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	err := s.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	remoteAuthChallengers := map[string]authChallenger{}
+	for _, rmt := range remotes {
+		cs, err := configureAuth(rmt.username, rmt.passwd, rmt.rawUrl)
+		if err != nil {
+			return nil, err
+		}
+		remoteAuthChallengers[rmt.url.Host] = &remoteAuthChallenger{
+			remoteURL: *rmt.url,
+			cm:        challenge.NewSimpleManager(),
+			cs:        cs,
+		}
+	}
+
+	return &proxyingRegistry{
+		embedded:        registry,
+		scheduler:       s,
+		authChallengers: remoteAuthChallengers,
+	}, nil
+}
+
+func NewRegistryPullThroughWithNothing(ctx context.Context, registry distribution.Namespace, driver driver.StorageDriver) (distribution.Namespace, error) {
+	remoteAuthChallengers := map[string]authChallenger{}
+	// give a empty scheduler
+	s := scheduler.New(ctx, driver, "/scheduler-state.json")
+	return &proxyingRegistry{
+		embedded:        registry,
+		scheduler:       s,
+		authChallengers: remoteAuthChallengers,
+	}, nil
+}
+
 func (pr *proxyingRegistry) Scope() distribution.Scope {
 	return distribution.GlobalScope
 }
@@ -118,8 +242,54 @@ func (pr *proxyingRegistry) Repositories(ctx context.Context, repos []string, la
 	return pr.embedded.Repositories(ctx, repos, last)
 }
 
+func (pr *proxyingRegistry) addChallengerDynamically(authConfig AuthConfig, endpoint *url.URL) (*remoteAuthChallenger, error) {
+	var (
+		err  error
+		sURL *url.URL
+		cs   auth.CredentialStore
+		c    *remoteAuthChallenger
+	)
+
+	if !strings.HasPrefix(authConfig.ServerAddress, "https://") && !strings.HasPrefix(authConfig.ServerAddress, "http://") {
+		authConfig.ServerAddress = "https://" + authConfig.ServerAddress
+	}
+
+	sURL, err = url.Parse(authConfig.ServerAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	cs, err = configureAuth(authConfig.Username, authConfig.Password, authConfig.ServerAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to config auth for %s", authConfig.ServerAddress)
+	}
+
+	c = &remoteAuthChallenger{
+		remoteURL: *sURL,
+		cm:        challenge.NewSimpleManager(),
+		cs:        cs,
+	}
+	//TODO consider if it's necessary to sync this config into config file
+	//pr.authChallengersMux.Lock()
+	//pr.authChallengers[endpoint.Host] = c
+	//pr.authChallengersMux.Unlock()
+	return c, nil
+}
+
 func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named) (distribution.Repository, error) {
-	c := pr.authChallenger
+	var (
+		c         = pr.authChallenger
+		remoteUrl = pr.remoteURL
+		err       error
+	)
+
+	c, remoteUrl, err = pr.getChallengerFromMirrorHeader(ctx, c, remoteUrl)
+	if err != nil {
+		logrus.Warnf("failed to get challenger, try to use default challenger, err: %s", err)
+		// always return a default challenger, just to make sure the local registry could work
+		c = pr.defaultChallenger()
+		remoteUrl = *DefaultV2Registry
+	}
 
 	tkopts := auth.TokenHandlerOptions{
 		Transport:   http.DefaultTransport,
@@ -146,7 +316,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 		return nil, err
 	}
 
-	remoteRepo, err := client.NewRepository(name, pr.remoteURL.String(), tr)
+	remoteRepo, err := client.NewRepository(name, remoteUrl.String(), tr)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +332,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 			remoteStore:    remoteRepo.Blobs(ctx),
 			scheduler:      pr.scheduler,
 			repositoryName: name,
-			authChallenger: pr.authChallenger,
+			authChallenger: c,
 		},
 		manifests: &proxyManifestStore{
 			repositoryName:  name,
@@ -170,13 +340,13 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 			remoteManifests: remoteManifests,
 			ctx:             ctx,
 			scheduler:       pr.scheduler,
-			authChallenger:  pr.authChallenger,
+			authChallenger:  c,
 		},
 		name: name,
 		tags: &proxyTagService{
 			localTags:      localRepo.Tags(ctx),
 			remoteTags:     remoteRepo.Tags(ctx),
-			authChallenger: pr.authChallenger,
+			authChallenger: c,
 		},
 	}, nil
 }
@@ -187,6 +357,114 @@ func (pr *proxyingRegistry) Blobs() distribution.BlobEnumerator {
 
 func (pr *proxyingRegistry) BlobStatter() distribution.BlobStatter {
 	return pr.embedded.BlobStatter()
+}
+
+func parseMirrorOriginalDomain(endp string) (*url.URL, error) {
+	if !strings.HasPrefix(endp, "https://") && !strings.HasPrefix(endp, "http://") {
+		endp = "https://" + endp
+	}
+
+	return url.Parse(endp)
+}
+
+func (pr *proxyingRegistry) getChallengerFromMirrorHeader(ctx context.Context, c authChallenger, rurl url.URL) (authChallenger, url.URL, error) {
+	// remoteUrl is not set, the option remoteregistries is configured definitely.
+	// Otherwise, the func (pr *proxyingRegistry) Repository won't be called.
+	// So, no need to check the len for challengers
+	if c != nil {
+		return c, rurl, nil
+	}
+
+	req, err := dcontext.GetRequest(ctx)
+	if err != nil {
+		return nil, url.URL{}, err
+	}
+	// domain comes from docker daemon pull request
+	// hacked docker pull a.hub/ns/nginx:latest will add https/http://a.hub to the header of pull request
+	// so we can know where is the original domain for pull request
+	endp := req.Header.Get("domain")
+	if endp == "" {
+		// just return, outside will return a default repository
+		return nil, url.URL{}, errors.New("failed to get repository, err: domain is empty")
+	}
+	endpoint, err := parseMirrorOriginalDomain(endp)
+	if err != nil {
+		return nil, url.URL{}, fmt.Errorf("failed to parse mirror-original-domain %s to url, err: %s", endp, err)
+	}
+	pr.authChallengersMux.RLock()
+	c = pr.authChallengers[endpoint.Host]
+	pr.authChallengersMux.RUnlock()
+	if c == nil {
+		authConfig := req.Header.Get("domain-auth")
+		dst, err := base64.StdEncoding.DecodeString(authConfig)
+		if err != nil {
+			return nil, url.URL{}, fmt.Errorf("failed to decode authConfig in base64")
+		}
+
+		dAuthConfig := AuthConfig{}
+		err = json.Unmarshal(dst, &dAuthConfig)
+		if err != nil {
+			return nil, url.URL{}, fmt.Errorf("failed to unmarshal authconfig %v, err: %s", authConfig, err)
+		}
+		// get from header if challenger is empty
+		// in sealer-hacked docker, this filed may same as "domain" header
+		if dAuthConfig.ServerAddress == "" {
+			c, err = pr.defaultChallengerForCertainServer(endpoint)
+			if err != nil {
+				return nil, url.URL{}, fmt.Errorf("failed to find get default chanllengers for %s, err: %s", endp, err)
+			}
+		} else {
+			c, err = pr.addChallengerDynamically(dAuthConfig, endpoint)
+			if err != nil {
+				return nil, url.URL{}, err
+			}
+		}
+	}
+	// won't happen
+	rac, ok := c.(*remoteAuthChallenger)
+	if !ok {
+		return nil, url.URL{}, errors.New("failed to transform proxy registry authChallenger to remoteAuthChallenger")
+	}
+	return c, rac.remoteURL, nil
+}
+
+func (pr *proxyingRegistry) defaultChallenger() *remoteAuthChallenger {
+	pr.authChallengersMux.RLock()
+	c := pr.authChallengers[DefaultV2Registry.Host]
+	pr.authChallengersMux.RUnlock()
+	if c != nil {
+		return c.(*remoteAuthChallenger)
+	}
+
+	cs, err := configureAuth("", "", DefaultV2Registry.String())
+	if err != nil {
+		logrus.Warnf("failed to config auth for %s, give a final default challenger", DefaultV2Registry.String())
+		// do not store the challenger
+		return &remoteAuthChallenger{
+			remoteURL: *DefaultV2Registry,
+			cm:        challenge.NewSimpleManager(),
+			cs:        credentials{creds: map[string]userpass{}},
+		}
+	}
+	// do not store the challenger
+	return &remoteAuthChallenger{
+		remoteURL: *DefaultV2Registry,
+		cm:        challenge.NewSimpleManager(),
+		cs:        cs,
+	}
+}
+
+func (pr *proxyingRegistry) defaultChallengerForCertainServer(endpoint *url.URL) (*remoteAuthChallenger, error) {
+	cs, err := configureAuth("", "", endpoint.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to config auth for %s", endpoint.String())
+	}
+	// do not store the challenger
+	return &remoteAuthChallenger{
+		remoteURL: *endpoint,
+		cm:        challenge.NewSimpleManager(),
+		cs:        cs,
+	}, nil
 }
 
 // authChallenger encapsulates a request to the upstream to establish credential challenges

--- a/registry/test.go
+++ b/registry/test.go
@@ -1,0 +1,31 @@
+package registry
+
+const cacheConfig = `
+version: 0.1
+log:
+  level: debug
+  fields:
+    service: registry
+    environment: development
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+    addr: :5000
+    secret: asecretforlocaldevelopment
+    debug:
+        addr: localhost:5001
+    headers:
+        X-Content-Type-Options: [nosniff]
+proxy:
+  remoteurl: https://registry-1.docker.io
+  username: username
+  password: password
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3
+`

--- a/registry/test.go
+++ b/registry/test.go
@@ -3,26 +3,21 @@ package registry
 const cacheConfig = `
 version: 0.1
 log:
-  level: debug
   fields:
     service: registry
-    environment: development
 storage:
   cache:
     blobdescriptor: inmemory
   filesystem:
     rootdirectory: /var/lib/registry
 http:
-    addr: :5000
-    secret: asecretforlocaldevelopment
-    debug:
-        addr: localhost:5001
-    headers:
-        X-Content-Type-Options: [nosniff]
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
 proxy:
-  remoteurl: https://registry-1.docker.io
-  username: username
-  password: password
+  remoteurl: https://registry.cn-qingdao.aliyuncs.com
+  username:
+  password:
 health:
   storagedriver:
     enabled: true


### PR DESCRIPTION
### registry config
1. config with registry auth info
```yaml
version: 0.1
log:
  fields:
    service: registry
storage:
  cache:
    blobdescriptor: inmemory
  filesystem:
    rootdirectory: /var/lib/registry
http:
  addr: :5000
  headers:
    X-Content-Type-Options: [nosniff]
proxy:
  remoteregistries:
  # will cache image from docker pull docker.io/library/nginx:latest or docker pull nginx
  - url: https://registry-1.docker.io #dockerhub default registry
    username:
    password:
    # will cache image from docker pull reg.test1.com/library/nginx:latest
  - url: https://reg.test1.com
    username: username
    password: password
  - url: http://reg.test2.com
    username: username
    password: password
health:
  storagedriver:
    enabled: true
    interval: 10s
    threshold: 3
```

2. or config with nothing remote registry info, we can get these info dynamically.
```yaml
version: 0.1
log:
  fields:
    service: registry
storage:
  cache:
    blobdescriptor: inmemory
  filesystem:
    rootdirectory: /var/lib/registry
http:
  addr: :5000
  headers:
    X-Content-Type-Options: [nosniff]
proxy:
  #turn on the proxy ability, but with noting registry auth info.
  on: true
health:
  storagedriver:
    enabled: true
    interval: 10s
    threshold: 3
```

registry config should be mounted as /etc/docker/registry/config.yml, and mount host /var/lib/registry using -v /var/lib/registry/:/var/lib/registry/ to store image cache